### PR TITLE
Doc review for issue 485

### DIFF
--- a/cmd/minishift/cmd/config/config.go
+++ b/cmd/minishift/cmd/config/config.go
@@ -52,54 +52,78 @@ const (
 
 var (
 	// minishift
-	ISOUrl           = createFlag("iso-url", SetString, []setFn{IsValidUrl}, []setFn{RequiresRestartMsg}, true)
-	CPUs             = createFlag("cpus", SetInt, []setFn{IsPositive}, []setFn{RequiresRestartMsg}, true)
-	Memory           = createFlag("memory", SetInt, []setFn{IsPositive}, []setFn{RequiresRestartMsg}, true)
-	DiskSize         = createFlag("disk-size", SetString, []setFn{IsValidDiskSize}, []setFn{RequiresRestartMsg}, true)
-	VmDriver         = createFlag("vm-driver", SetString, []setFn{IsValidDriver}, []setFn{RequiresRestartMsg}, true)
-	OpenshiftVersion = createFlag("openshift-version", SetString, nil, nil, true)
-	HostOnlyCIDR     = createFlag("host-only-cidr", SetString, []setFn{IsValidCIDR}, nil, true)
-	DockerEnv        = createFlag("docker-env", SetSlice, nil, nil, true)
-	DockerEngineOpt  = createFlag("docker-opt", SetSlice, nil, nil, true)
-	InsecureRegistry = createFlag("insecure-registry", SetSlice, nil, nil, true)
-	RegistryMirror   = createFlag("registry-mirror", SetSlice, nil, nil, true)
-	AddonEnv         = createFlag("addon-env", SetSlice, nil, nil, true)
+	ISOUrl           = createConfigSetting("iso-url", SetString, []setFn{IsValidUrl}, []setFn{RequiresRestartMsg}, true)
+	CPUs             = createConfigSetting("cpus", SetInt, []setFn{IsPositive}, []setFn{RequiresRestartMsg}, true)
+	Memory           = createConfigSetting("memory", SetInt, []setFn{IsPositive}, []setFn{RequiresRestartMsg}, true)
+	DiskSize         = createConfigSetting("disk-size", SetString, []setFn{IsValidDiskSize}, []setFn{RequiresRestartMsg}, true)
+	VmDriver         = createConfigSetting("vm-driver", SetString, []setFn{IsValidDriver}, []setFn{RequiresRestartMsg}, true)
+	OpenshiftVersion = createConfigSetting("openshift-version", SetString, nil, nil, true)
+	HostOnlyCIDR     = createConfigSetting("host-only-cidr", SetString, []setFn{IsValidCIDR}, nil, true)
+	DockerEnv        = createConfigSetting("docker-env", SetSlice, nil, nil, true)
+	DockerEngineOpt  = createConfigSetting("docker-opt", SetSlice, nil, nil, true)
+	InsecureRegistry = createConfigSetting("insecure-registry", SetSlice, nil, nil, true)
+	RegistryMirror   = createConfigSetting("registry-mirror", SetSlice, nil, nil, true)
+	AddonEnv         = createConfigSetting("addon-env", SetSlice, nil, nil, true)
 
 	// cluster up
-	SkipRegistryCheck = createFlag("skip-registry-check", SetBool, nil, nil, true)
-	PublicHostname    = createFlag("public-hostname", SetString, nil, nil, true)
-	RoutingSuffix     = createFlag("routing-suffix", SetString, nil, nil, true)
-	HostConfigDir     = createFlag("host-config-dir", SetString, []setFn{IsValidPath}, nil, true)
-	HostVolumeDir     = createFlag("host-volumes-dir", SetString, []setFn{IsValidPath}, nil, true)
-	HostDataDir       = createFlag("host-data-dir", SetString, []setFn{IsValidPath}, nil, true)
-	HostPvDir         = createFlag("host-pv-dir", SetString, []setFn{IsValidPath}, nil, true)
-	ServerLogLevel    = createFlag("server-loglevel", SetInt, []setFn{IsPositive}, nil, true)
-	OpenshiftEnv      = createFlag("openshift-env", nil, nil, nil, false)
-	Metrics           = createFlag("metrics", SetBool, nil, nil, true)
-	Logging           = createFlag("logging", SetBool, nil, nil, true)
+	SkipRegistryCheck = createConfigSetting("skip-registry-check", SetBool, nil, nil, true)
+	PublicHostname    = createConfigSetting("public-hostname", SetString, nil, nil, true)
+	RoutingSuffix     = createConfigSetting("routing-suffix", SetString, nil, nil, true)
+	HostConfigDir     = createConfigSetting("host-config-dir", SetString, []setFn{IsValidPath}, nil, true)
+	HostVolumeDir     = createConfigSetting("host-volumes-dir", SetString, []setFn{IsValidPath}, nil, true)
+	HostDataDir       = createConfigSetting("host-data-dir", SetString, []setFn{IsValidPath}, nil, true)
+	HostPvDir         = createConfigSetting("host-pv-dir", SetString, []setFn{IsValidPath}, nil, true)
+	ServerLogLevel    = createConfigSetting("server-loglevel", SetInt, []setFn{IsPositive}, nil, true)
+	OpenshiftEnv      = createConfigSetting("openshift-env", nil, nil, nil, false)
+	Metrics           = createConfigSetting("metrics", SetBool, nil, nil, true)
+	Logging           = createConfigSetting("logging", SetBool, nil, nil, true)
 
 	// Setting proxy
-	NoProxyList = createFlag("no-proxy", SetString, nil, nil, true)
-	HttpProxy   = createFlag("http-proxy", SetString, []setFn{IsValidProxy}, nil, true)
-	HttpsProxy  = createFlag("https-proxy", SetString, []setFn{IsValidProxy}, nil, true)
+	NoProxyList = createConfigSetting("no-proxy", SetString, nil, nil, true)
+	HttpProxy   = createConfigSetting("http-proxy", SetString, []setFn{IsValidProxy}, nil, true)
+	HttpsProxy  = createConfigSetting("https-proxy", SetString, []setFn{IsValidProxy}, nil, true)
 
 	// Subscription Manager
-	Username         = createFlag("username", SetString, nil, nil, true)
-	Password         = createFlag("password", SetString, nil, nil, true)
-	SkipRegistration = createFlag("skip-registration", SetBool, nil, nil, true)
+	Username         = createConfigSetting("username", SetString, nil, nil, true)
+	Password         = createConfigSetting("password", SetString, nil, nil, true)
+	SkipRegistration = createConfigSetting("skip-registration", SetBool, nil, nil, true)
 
 	// Global flags
-	LogDir             = createFlag("log_dir", SetString, []setFn{IsValidPath}, nil, true)
-	ShowLibmachineLogs = createFlag("show-libmachine-logs", SetBool, nil, nil, true)
+	LogDir             = createConfigSetting("log_dir", SetString, []setFn{IsValidPath}, nil, true)
+	ShowLibmachineLogs = createConfigSetting("show-libmachine-logs", SetBool, nil, nil, true)
 
 	// Host Folders
-	HostFoldersMountPath = createFlag("hostfolders-mountpath", SetString, nil, nil, true)
-	HostFoldersAutoMount = createFlag("hostfolders-automount", SetBool, nil, nil, true)
+	HostFoldersMountPath = createConfigSetting("hostfolders-mountpath", SetString, nil, nil, true)
+	HostFoldersAutoMount = createConfigSetting("hostfolders-automount", SetBool, nil, nil, true)
 
-	ImageCaching = createFlag("image-caching", SetBool, nil, nil, true)
+	ImageCaching = createConfigSetting("image-caching", SetBool, nil, nil, true)
+
+	// Preflight checks (before start)
+	SkipCheckKVMDriver    = createConfigSetting("skip-check-kvm-driver", SetBool, nil, nil, true)
+	WarnCheckKVMDriver    = createConfigSetting("warn-check-kvm-driver", SetBool, nil, nil, true)
+	SkipCheckXHyveDriver  = createConfigSetting("skip-check-xhyve-driver", SetBool, nil, nil, true)
+	WarnCheckXHyveDriver  = createConfigSetting("warn-check-xhyve-driver", SetBool, nil, nil, true)
+	SkipCheckHyperVDriver = createConfigSetting("skip-check-hyperv-driver", SetBool, nil, nil, true)
+	WarnCheckHyperVDriver = createConfigSetting("warn-check-hyperv-driver", SetBool, nil, nil, true)
+	// Preflight checks (after start)
+	SkipInstanceIP        = createConfigSetting("skip-check-instance-ip", SetBool, nil, nil, true)
+	WarnInstanceIP        = createConfigSetting("warn-check-instance-ip", SetBool, nil, nil, true)
+	SkipCheckNetworkHost  = createConfigSetting("skip-check-network-host", SetBool, nil, nil, true)
+	WarnCheckNetworkHost  = createConfigSetting("warn-check-network-host", SetBool, nil, nil, true)
+	SkipCheckNetworkPing  = createConfigSetting("skip-check-network-ping", SetBool, nil, nil, true)
+	WarnCheckNetworkPing  = createConfigSetting("warn-check-network-ping", SetBool, nil, nil, true)
+	SkipCheckNetworkHTTP  = createConfigSetting("skip-check-network-http", SetBool, nil, nil, true)
+	WarnCheckNetworkHTTP  = createConfigSetting("warn-check-network-http", SetBool, nil, nil, true)
+	SkipCheckStorageMount = createConfigSetting("skip-check-storage-mount", SetBool, nil, nil, true)
+	WarnCheckStorageMount = createConfigSetting("warn-check-storage-mount", SetBool, nil, nil, true)
+	SkipCheckStorageUsage = createConfigSetting("skip-check-storage-usage", SetBool, nil, nil, true)
+	WarnCheckStorageUsage = createConfigSetting("warn-check-storage-usage", SetBool, nil, nil, true)
+	// Preflight values
+	CheckNetworkHttpHost = createConfigSetting("check-network-http-host", SetString, nil, nil, true)
+	CheckNetworkPingHost = createConfigSetting("check-network-ping-host", SetString, nil, nil, true)
 )
 
-func createFlag(name string, set func(MinishiftConfig, string, string) error, validations []setFn, callbacks []setFn, isApply bool) *Setting {
+func createConfigSetting(name string, set func(MinishiftConfig, string, string) error, validations []setFn, callbacks []setFn, isApply bool) *Setting {
 	flag := Setting{
 		Name:        name,
 		set:         set,

--- a/cmd/minishift/cmd/openshift/service.go
+++ b/cmd/minishift/cmd/openshift/service.go
@@ -165,7 +165,7 @@ func printToStdOut(serviceSpecs []openshift.ServiceSpec, ip string) {
 		}
 	}
 	table := tablewriter.NewWriter(os.Stdout)
-	table.SetHeader([]string{"Namsepace", "Name", "NodePort", "Route-URL", "Weight"})
+	table.SetHeader([]string{"Namespace", "Name", "NodePort", "Route-URL", "Weight"})
 	table.SetBorders(tablewriter.Border{Left: true, Top: true, Right: true, Bottom: true})
 	table.SetCenterSeparator("|")
 	table.AppendBulk(data)

--- a/cmd/minishift/cmd/openshift/service_list.go
+++ b/cmd/minishift/cmd/openshift/service_list.go
@@ -83,7 +83,7 @@ var serviceListCmd = &cobra.Command{
 		}
 
 		table := tablewriter.NewWriter(os.Stdout)
-		table.SetHeader([]string{"Namsepace", "Name", "NodePort", "Route-URL", "Weight"})
+		table.SetHeader([]string{"Namespace", "Name", "NodePort", "Route-URL", "Weight"})
 		table.SetBorders(tablewriter.Border{Left: true, Top: true, Right: true, Bottom: true})
 		table.SetCenterSeparator("|")
 		table.AppendBulk(data) // Add Bulk Data

--- a/cmd/minishift/cmd/ssh.go
+++ b/cmd/minishift/cmd/ssh.go
@@ -26,6 +26,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	SshCommunicationError = "exit status 255"
+)
+
 // sshCmd represents the docker-machine ssh command
 var sshCmd = &cobra.Command{
 	Use:   "ssh [-- COMMAND]",
@@ -34,9 +38,13 @@ var sshCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		api := libmachine.NewClient(constants.Minipath, constants.MakeMiniPath("certs"))
 		defer api.Close()
+
 		err := cluster.CreateSSHShell(api, args)
 		if err != nil {
-			atexit.ExitWithMessage(1, fmt.Sprintf("Cannot establish SSH connection to the VM: %s", err.Error()))
+			if err.Error() == SshCommunicationError {
+				atexit.ExitWithMessage(1, fmt.Sprintf("Cannot establish SSH connection to the VM: %s", err.Error()))
+			}
+			atexit.ExitWithMessage(1, fmt.Sprintf("Command failed: %s", err.Error()))
 		}
 	},
 }

--- a/cmd/minishift/cmd/start.go
+++ b/cmd/minishift/cmd/start.go
@@ -22,8 +22,10 @@ import (
 	"strings"
 
 	"os"
+	"time"
 
 	"github.com/asaskevich/govalidator"
+	"github.com/briandowns/spinner"
 	units "github.com/docker/go-units"
 	"github.com/docker/machine/libmachine"
 	"github.com/docker/machine/libmachine/drivers"
@@ -44,6 +46,7 @@ import (
 	"github.com/minishift/minishift/pkg/minishift/hostfolder"
 	"github.com/minishift/minishift/pkg/minishift/openshift"
 	"github.com/minishift/minishift/pkg/minishift/provisioner"
+
 	"github.com/minishift/minishift/pkg/util"
 	inputUtils "github.com/minishift/minishift/pkg/util"
 	"github.com/minishift/minishift/pkg/util/os/atexit"
@@ -62,6 +65,8 @@ const (
 	defaultInsecureRegistry = "172.30.0.0/16"
 
 	unsupportedIsoUrlFormat = "Unsupported value for iso-url. It can be an URL, file URI or one of the following short names: [b2d centos]."
+
+	SPINNER_SPEED = 200 // In milliseconds
 )
 
 var (
@@ -126,6 +131,10 @@ func runStart(cmd *cobra.Command, args []string) {
 
 	ensureNotRunning(libMachineClient, constants.MachineName)
 	validateOpenshiftVersion()
+
+	// preflight check (before start)
+	preflightChecksBeforeStartingHost()
+
 	setSubscriptionManagerParameters()
 
 	proxyConfig := handleProxies()
@@ -134,8 +143,13 @@ func runStart(cmd *cobra.Command, args []string) {
 	// we need to determine whether this is a restart prior to potentially creating a new VM
 	isRestart := cmdutil.VMExists(libMachineClient, constants.MachineName)
 
-	hostVm, ip := startHost(libMachineClient)
+	fmt.Printf("-- Starting local OpenShift cluster")
+	hostVm := startHost(libMachineClient)
 	registerHost(libMachineClient)
+
+	// preflight checks (after start)
+	preflightChecksAfterStartingHost(hostVm.Driver)
+	ip, _ := hostVm.Driver.GetIP()
 
 	if proxyConfig.IsEnabled() {
 		// once we know the IP, we need to make sure it is not proxied in a proxy environment
@@ -259,7 +273,10 @@ func determineInsecureRegistry(key string) []string {
 	return append(s, defaultInsecureRegistry)
 }
 
-func startHost(libMachineClient *libmachine.Client) (*host.Host, string) {
+func startHost(libMachineClient *libmachine.Client) *host.Host {
+	spinnerView := spinner.New(spinner.CharSets[9], SPINNER_SPEED*time.Millisecond)
+
+	// Configuration used for creation/setup of the Virtual Machine
 	machineConfig := &cluster.MachineConfig{
 		MinikubeISO:      determineIsoUrl(viper.GetString(startFlags.ISOUrl.Name)),
 		Memory:           viper.GetInt(startFlags.Memory.Name),
@@ -274,11 +291,24 @@ func startHost(libMachineClient *libmachine.Client) (*host.Host, string) {
 		ShellProxyEnv:    shellProxyEnv,
 	}
 
-	fmt.Printf("Starting local OpenShift cluster using '%s' hypervisor...\n", machineConfig.VMDriver)
+	fmt.Printf(" using '%s' hypervisor ...\n", machineConfig.VMDriver)
 	var hostVm *host.Host
+
+	// configuration with these settings only happen on create
+	isRestart := cmdutil.VMExists(libMachineClient, constants.MachineName)
+	if !isRestart {
+		fmt.Println("-- Instance will be configured with ...")
+		fmt.Println("   Memory:   ", units.HumanSize(float64((machineConfig.Memory/units.KiB)*units.GB)))
+		fmt.Println("   vCPUs :   ", machineConfig.CPUs)
+		fmt.Println("   Disksize: ", units.HumanSize(float64(machineConfig.DiskSize*units.MB)))
+		fmt.Println("   Boot ISO: ", machineConfig.MinikubeISO)
+	}
+	fmt.Printf("-- Starting Minishift VM ... ")
+	spinnerView.Start()
 	start := func() (err error) {
 		hostVm, err = cluster.StartHost(libMachineClient, *machineConfig)
 		if err != nil {
+			fmt.Printf("FAIL ")
 			glog.Errorf("Error starting the VM: %s. Retrying.\n", err)
 		}
 		return err
@@ -287,13 +317,10 @@ func startHost(libMachineClient *libmachine.Client) (*host.Host, string) {
 	if err != nil {
 		atexit.ExitWithMessage(1, fmt.Sprintf("Error starting the VM: %v", err))
 	}
+	spinnerView.Stop()
+	fmt.Println("OK")
 
-	ip, err := hostVm.Driver.GetIP()
-	if err != nil {
-		atexit.ExitWithMessage(1, fmt.Sprintf("Error determining host ip: %v ", err))
-	}
-
-	return hostVm, ip
+	return hostVm
 }
 
 func autoMountHostFolders(driver drivers.Driver) {

--- a/cmd/minishift/cmd/start_preflight.go
+++ b/cmd/minishift/cmd/start_preflight.go
@@ -1,0 +1,304 @@
+/*
+Copyright (C) 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/docker/machine/libmachine/drivers"
+	startFlags "github.com/minishift/minishift/cmd/minishift/cmd/config"
+	miniutil "github.com/minishift/minishift/pkg/minishift/util"
+
+	"github.com/minishift/minishift/pkg/util/os/atexit"
+	"github.com/spf13/viper"
+)
+
+const (
+	StorageDisk = "/mnt/sda1"
+)
+
+func preflightChecksBeforeStartingHost() {
+	switch viper.GetString(startFlags.VmDriver.Name) {
+	case "xhyve":
+		preflightCheckSucceedsOrFails(
+			startFlags.SkipCheckXHyveDriver.Name,
+			checkXhyveDriver,
+			"Checking if 'xhyve' driver installed",
+			false, startFlags.WarnCheckXHyveDriver.Name,
+			"See install guide")
+	case "kvm":
+		preflightCheckSucceedsOrFails(
+			startFlags.SkipCheckKVMDriver.Name,
+			checkKvmDriver,
+			"Checking if 'kvm' driver installed",
+			false, startFlags.WarnCheckXHyveDriver.Name,
+			"See install guide")
+	case "hyperv":
+		preflightCheckSucceedsOrFails(
+			startFlags.SkipCheckHyperVDriver.Name,
+			checkHypervDriver,
+			"Checking if 'hyperv' driver configured",
+			false, startFlags.WarnCheckHyperVDriver.Name,
+			"Hyper-V virtual switch not set")
+	}
+}
+
+func preflightChecksAfterStartingHost(driver drivers.Driver) {
+	preflightCheckSucceedsOrFailsWithDriver(
+		startFlags.SkipInstanceIP.Name,
+		checkInstanceIP, driver,
+		"Checking for IP",
+		false, startFlags.WarnInstanceIP.Name,
+		"Error determining IP")
+	/*
+		// This happens too late in the preflight, as provisioning needs an IP already
+			preflightCheckSucceedsOrFailsWithDriver(
+				startFlags.SkipCheckNetworkHost.Name,
+				checkVMConnectivity, driver,
+				"Checking if VM is reachable from host",
+				startFlags.WarnCheckNetworkHost.Name,
+				"Please check our troubleshooting guide")
+	*/
+	preflightCheckSucceedsOrFailsWithDriver(
+		startFlags.SkipCheckNetworkPing.Name,
+		checkIPConnectivity, driver,
+		"Checking host reachable from VM",
+		true, startFlags.WarnCheckNetworkPing.Name,
+		"Instance is unable to ping outside")
+	preflightCheckSucceedsOrFailsWithDriver(
+		startFlags.SkipCheckNetworkHTTP.Name,
+		checkHttpConnectivity, driver,
+		"Checking HTTP connectivity from VM",
+		true, startFlags.WarnCheckNetworkHTTP.Name,
+		"Instance is unable to retieve from address")
+	preflightCheckSucceedsOrFailsWithDriver(
+		startFlags.SkipCheckStorageMount.Name,
+		checkStorageMounted, driver,
+		"Checking storage disk mounted",
+		false, startFlags.WarnCheckStorageMount.Name,
+		"Instance did not mount persistent storage volume")
+	preflightCheckSucceedsOrFailsWithDriver(
+		startFlags.SkipCheckStorageUsage.Name,
+		checkStorageUsage, driver,
+		"Checking storage disk usage",
+		false, startFlags.WarnCheckStorageUsage.Name,
+		"Instance does not have enough storage available")
+}
+
+type preflightCheckFunc func() bool
+type preflightCheckWithDriverFunc func(driver drivers.Driver) bool
+
+// setting configNameOverrideIfSkipped to true will SKIP the check
+// setting treatAsWarning and/or configNameOverrideIfWarning to true will WARN if check failed instead or FAIL
+func preflightCheckSucceedsOrFails(configNameOverrideIfSkipped string, execute preflightCheckFunc, message string, treatAsWarning bool, configNameOverrideIfWarning string, errorMessage string) {
+	fmt.Printf("-- %s ... ", message)
+
+	isConfiguredToSkip := viper.GetBool(configNameOverrideIfSkipped)
+	isConfiguredToWarn := viper.GetBool(configNameOverrideIfWarning)
+
+	if isConfiguredToSkip {
+		fmt.Println("SKIP")
+		return
+	}
+
+	if execute() {
+		fmt.Println("OK")
+		return
+	}
+
+	fmt.Println("FAIL")
+	errorMessage = fmt.Sprintf("   %s", errorMessage)
+	if isConfiguredToWarn || treatAsWarning {
+		fmt.Println(errorMessage)
+	} else {
+		atexit.ExitWithMessage(1, errorMessage)
+	}
+}
+
+func preflightCheckSucceedsOrFailsWithDriver(configNameOverrideIfSkipped string, execute preflightCheckWithDriverFunc, driver drivers.Driver, message string, treatAsWarning bool, configNameOverrideIfWarning string, errorMessage string) {
+	fmt.Printf("-- %s ... ", message)
+
+	isConfiguredToSkip := viper.GetBool(configNameOverrideIfSkipped)
+	isConfiguredToWarn := viper.GetBool(configNameOverrideIfWarning)
+
+	if isConfiguredToSkip {
+		fmt.Println("SKIP")
+		return
+	}
+
+	if execute(driver) {
+		fmt.Println("OK")
+		return
+	}
+
+	fmt.Println("FAIL")
+	errorMessage = fmt.Sprintf("   %s", errorMessage)
+	if isConfiguredToWarn || treatAsWarning {
+		fmt.Println(errorMessage)
+	} else {
+		atexit.ExitWithMessage(1, errorMessage)
+	}
+}
+
+func checkXhyveDriver() bool {
+	path, err := exec.LookPath("docker-machine-driver-xhyve")
+
+	if err != nil {
+		return false
+	}
+
+	fi, _ := os.Stat(path)
+	// follow symlinks
+	if fi.Mode()&os.ModeSymlink != 0 {
+		path, err = os.Readlink(path)
+		if err != nil {
+			return false
+		}
+	}
+	fmt.Println("\n   Driver is available at", path)
+
+	fmt.Printf("   Checking for setuid bit ... ")
+	if fi.Mode()&os.ModeSetuid == 0 {
+		return false
+	}
+
+	return true
+}
+
+func checkKvmDriver() bool {
+	path, err := exec.LookPath("docker-machine-driver-kvm")
+	if err != nil {
+		return false
+	}
+	fmt.Printf(fmt.Sprintf("\n   Driver is available at %s ... ", path))
+
+	return true
+}
+
+func checkHypervDriver() bool {
+	switchEnv := os.Getenv("HYPERV_VIRTUAL_SWITCH")
+	if switchEnv == "" {
+		return false
+	}
+	return true
+}
+
+// Check to make sure the instance has an IPv4 address.
+// HyperV will issue IPv6 addresses on Internal virtual switch
+// https://github.com/minishift/minishift/issues/418
+func checkInstanceIP(driver drivers.Driver) bool {
+	ip, err := driver.GetIP()
+	if err == nil && net.ParseIP(ip).To4() != nil {
+		return true
+	}
+	return false
+}
+
+//
+func checkVMConnectivity(driver drivers.Driver) bool {
+	// used to check if the host can reach the VM
+	ip, _ := driver.GetIP()
+
+	cmd := exec.Command("ping", "-n 1", ip)
+	stdoutStderr, err := cmd.CombinedOutput()
+	if err != nil {
+		return false
+	}
+	fmt.Printf("%s\n", stdoutStderr)
+	return false
+}
+
+// Checks if the VM has connectivity to the outside network
+func checkIPConnectivity(driver drivers.Driver) bool {
+	ipToPing := viper.GetString(startFlags.CheckNetworkPingHost.Name)
+	if ipToPing == "" {
+		ipToPing = "8.8.8.8"
+	}
+
+	fmt.Printf("\n   Pinging %s ... ", ipToPing)
+	return miniutil.IsIPReachable(driver, ipToPing, false)
+}
+
+// Allows to test outside connectivity and possible proxy support
+func checkHttpConnectivity(driver drivers.Driver) bool {
+	urlToRetrieve := viper.GetString(startFlags.CheckNetworkHttpHost.Name)
+	if urlToRetrieve == "" {
+		urlToRetrieve = "http://minishift.io/index.html"
+	}
+
+	fmt.Printf("\n   Retrieving %s ... ", urlToRetrieve)
+	return miniutil.IsRetrievable(driver, urlToRetrieve, false)
+}
+
+func checkStorageMounted(driver drivers.Driver) bool {
+	mounted, _ := isMounted(driver, StorageDisk)
+	return mounted
+}
+
+func checkStorageUsage(driver drivers.Driver) bool {
+	usedPercentage := getDiskUsage(driver, StorageDisk)
+	fmt.Printf("%s ", usedPercentage)
+	usedPercentage = strings.TrimRight(usedPercentage, "%")
+	usage, err := strconv.ParseInt(usedPercentage, 10, 8)
+	if err != nil {
+		return false
+	}
+
+	if usage > 80 && usage < 98 {
+		fmt.Printf("!!! ")
+	}
+	if usage < 98 {
+		return true
+	}
+	return false
+}
+
+func getDiskUsage(driver drivers.Driver, mountpoint string) string {
+	cmd := fmt.Sprintf(
+		"df -h %s | awk 'FNR > 1 {print $5}'",
+		mountpoint)
+
+	out, err := drivers.RunSSHCommandFromDriver(driver, cmd)
+
+	if err != nil {
+		return "ERR"
+	}
+
+	return strings.Trim(out, "\n")
+}
+
+func isMounted(driver drivers.Driver, mountpoint string) (bool, error) {
+	cmd := fmt.Sprintf(
+		"if grep -qs %s /proc/mounts; then echo '1'; else echo '0'; fi",
+		mountpoint)
+
+	out, err := drivers.RunSSHCommandFromDriver(driver, cmd)
+
+	if err != nil {
+		return false, err
+	}
+	if strings.Trim(out, "\n") == "0" {
+		return false, nil
+	}
+
+	return true, nil
+}

--- a/cmd/minishift/cmd/start_preflight.go
+++ b/cmd/minishift/cmd/start_preflight.go
@@ -42,23 +42,23 @@ func preflightChecksBeforeStartingHost() {
 		preflightCheckSucceedsOrFails(
 			startFlags.SkipCheckXHyveDriver.Name,
 			checkXhyveDriver,
-			"Checking if 'xhyve' driver installed",
+			"Checking if xhyve driver is installed",
 			false, startFlags.WarnCheckXHyveDriver.Name,
-			"See install guide")
+			"See the 'Setting Up the Driver Plug-in' topic for more information")
 	case "kvm":
 		preflightCheckSucceedsOrFails(
 			startFlags.SkipCheckKVMDriver.Name,
 			checkKvmDriver,
-			"Checking if 'kvm' driver installed",
+			"Checking if KVM driver is installed",
 			false, startFlags.WarnCheckXHyveDriver.Name,
-			"See install guide")
+			"See the 'Setting Up the Driver Plug-in' topic for more information")
 	case "hyperv":
 		preflightCheckSucceedsOrFails(
 			startFlags.SkipCheckHyperVDriver.Name,
 			checkHypervDriver,
-			"Checking if 'hyperv' driver configured",
+			"Checking if Hyper-V driver is configured",
 			false, startFlags.WarnCheckHyperVDriver.Name,
-			"Hyper-V virtual switch not set")
+			"Hyper-V virtual switch is not set")
 	}
 }
 
@@ -66,9 +66,9 @@ func preflightChecksAfterStartingHost(driver drivers.Driver) {
 	preflightCheckSucceedsOrFailsWithDriver(
 		startFlags.SkipInstanceIP.Name,
 		checkInstanceIP, driver,
-		"Checking for IP",
+		"Checking for IP address",
 		false, startFlags.WarnInstanceIP.Name,
-		"Error determining IP")
+		"Error determining IP address")
 	/*
 		// This happens too late in the preflight, as provisioning needs an IP already
 			preflightCheckSucceedsOrFailsWithDriver(
@@ -81,27 +81,27 @@ func preflightChecksAfterStartingHost(driver drivers.Driver) {
 	preflightCheckSucceedsOrFailsWithDriver(
 		startFlags.SkipCheckNetworkPing.Name,
 		checkIPConnectivity, driver,
-		"Checking host reachable from VM",
+		"Checking if external host is reachable from the Minishift VM",
 		true, startFlags.WarnCheckNetworkPing.Name,
-		"Instance is unable to ping outside")
+		"VM is unable to ping external host")
 	preflightCheckSucceedsOrFailsWithDriver(
 		startFlags.SkipCheckNetworkHTTP.Name,
 		checkHttpConnectivity, driver,
-		"Checking HTTP connectivity from VM",
+		"Checking HTTP connectivity from the VM",
 		true, startFlags.WarnCheckNetworkHTTP.Name,
-		"Instance is unable to retieve from address")
+		"VM cannot connect to external URL with HTTP")
 	preflightCheckSucceedsOrFailsWithDriver(
 		startFlags.SkipCheckStorageMount.Name,
 		checkStorageMounted, driver,
-		"Checking storage disk mounted",
+		"Checking if persisten storage volume is mounted",
 		false, startFlags.WarnCheckStorageMount.Name,
-		"Instance did not mount persistent storage volume")
+		"Persistent volume storage is not mounted")
 	preflightCheckSucceedsOrFailsWithDriver(
 		startFlags.SkipCheckStorageUsage.Name,
 		checkStorageUsage, driver,
-		"Checking storage disk usage",
+		"Checking available disk space",
 		false, startFlags.WarnCheckStorageUsage.Name,
-		"Instance does not have enough storage available")
+		"Insufficient disk space on the persistent storage volume")
 }
 
 type preflightCheckFunc func() bool

--- a/docs/source/getting-started/quickstart.adoc
+++ b/docs/source/getting-started/quickstart.adoc
@@ -50,8 +50,8 @@ To check the IP, run the `minishift ip` command.
 - By default, Minishift uses the driver most relevant to the host OS.
 To use a different driver, set the `--vm-driver` flag in `minishift start`.
 For example, to use VirtualBox instead of KVM on GNU/Linux operating systems, run `minishift start --vm-driver=virtualbox`.
-- During start we perform some checks to make sure the OpenShift cluster is able to start correctly.
-If a startup check fails, please check the xref:./setting-up-driver-plugin.adoc#[driver plugin setup] or the xref:../using/troubleshooting.adoc#[troubleshooting] guide 
+- While Minishift starts it runs several checks to make sure that the Minishift VM and the OpenShift cluster are able to start correctly.
+If any startup checks fail, see the xref:../using/troubleshooting.adoc#[troubleshooting] topic for information about possible causes and solutions.
 
 For more information about `minishift start` options, see the xref:../command-ref/minishift_start.adoc#[`minishift start`] command.
 ====

--- a/docs/source/getting-started/quickstart.adoc
+++ b/docs/source/getting-started/quickstart.adoc
@@ -29,7 +29,7 @@ The following steps describe how to get started with Minishift on a GNU/Linux op
 +
 ----
 $ minishift start
-Starting local OpenShift cluster using 'kvm' hypervisor...
+-- Starting local OpenShift cluster using 'kvm' hypervisor...
 ...
    OpenShift server started.
    The server is accessible via web console at:
@@ -50,6 +50,9 @@ To check the IP, run the `minishift ip` command.
 - By default, Minishift uses the driver most relevant to the host OS.
 To use a different driver, set the `--vm-driver` flag in `minishift start`.
 For example, to use VirtualBox instead of KVM on GNU/Linux operating systems, run `minishift start --vm-driver=virtualbox`.
+- During start we perform some checks to make sure the OpenShift cluster is able to start correctly.
+If a startup check fails, please check the xref:./setting-up-driver-plugin.adoc#[driver plugin setup] or the xref:../using/troubleshooting.adoc#[troubleshooting] guide 
+
 For more information about `minishift start` options, see the xref:../command-ref/minishift_start.adoc#[`minishift start`] command.
 ====
 

--- a/docs/source/using/troubleshooting.adoc
+++ b/docs/source/using/troubleshooting.adoc
@@ -243,3 +243,51 @@ Workaround: Avoid installing packages or storing large files in the root filesys
 Instead, you can create a sub-directory in the *_mnt/sda1/_* persistent storage volume or define and mount xref:../using/host-folders.adoc#[host folders] that can share storage space between the host and the Minishift VM.
 
 If you want to perform development tasks inside the Minishift VM, it is recommended that you use containers, which are stored in persistent storage volumes, and reuse the xref:../using/docker-daemon.adoc#[Minishift Docker daemon].
+
+
+[[minshift-start-failed-due-to-startup-check]]
+== Minishift startup check failed
+
+During the start of Minishift we perform several pre-flight checks to make sure the Minishift VM and OpenShift Cluster are able to start without any issues. Therefore, if something is not correctly configured, we fail a test and the startup will stop.
+
+If the startup failed for one of the driver plugins, please make sure they are correctly configured by checking the  xref:../getting-started/setting-up-driver-plugin.adoc#[setting up the driver plugin] topic. If for some reason you want to force the startup, you can configure Minishift to treat these errors as warnings as follows:
+
+. For KVM/Libvirt on Linux, run the following command:
+
+----
+$ minishift config set warn-check-kvm-driver true
+----
+
+. For xhyve on macOS, run the following command:
+
+----
+$ minishift config set warn-check-xhyve-driver true
+----
+
+. For Hyper-V on Windows, run the following command:
+
+----
+# minishift config set warn-check-hyperv-driver true
+----
+
+Other checks include to make sure the persistent volume storage is mounted, and/or enough storage is available. If for instance the Minishift VM has less than 95% of storage available, startup will fail. To be able to recover the data, it is possible to skip this test as follows:
+
+----
+$ minishift config set skip-check-storage-usage true
+----
+
+After the Minishift VM has started, we perform several basic network checks. These try to make sure if external connectivity is possible from within the Minishift VM. These checks by default are configured to treat the errors as warnings. This is due to the fact that the environment we are deployed in are quite diverse. To allow these checks to be useful for your environment you might want to configure them.
+
+One of the tests we perform is to ping an external host. You can change the host we try to reach with:
+
+----
+$ minishift config set check-network-ping-host 208.67.222.222
+----
+
+Note: To make this test work for you, use the address of your internal DNS, proxy host or an external host that you can reach from your workstation.
+
+Since proxy connectivity can be problematic, we also provide a test which will try to retrieve an external resource. While this test is treated as warning by default, the resource retrieved can be changed with the following command:
+
+----
+$ minishift config set check-network-http-host ddg.gg
+----

--- a/docs/source/using/troubleshooting.adoc
+++ b/docs/source/using/troubleshooting.adoc
@@ -245,49 +245,67 @@ Instead, you can create a sub-directory in the *_mnt/sda1/_* persistent storage 
 If you want to perform development tasks inside the Minishift VM, it is recommended that you use containers, which are stored in persistent storage volumes, and reuse the xref:../using/docker-daemon.adoc#[Minishift Docker daemon].
 
 
-[[minshift-start-failed-due-to-startup-check]]
+[[minshift-startup-check-failed]]
 == Minishift startup check failed
 
-During the start of Minishift we perform several pre-flight checks to make sure the Minishift VM and OpenShift Cluster are able to start without any issues. Therefore, if something is not correctly configured, we fail a test and the startup will stop.
+While Minishift starts, it runs several startup checks to make sure that the Minishift VM and the OpenShift Cluster are able to start without any issues.
+If any configuration is incorrect or missing, the startup checks fail and Minishift does not start.
 
-If the startup failed for one of the driver plugins, please make sure they are correctly configured by checking the  xref:../getting-started/setting-up-driver-plugin.adoc#[setting up the driver plugin] topic. If for some reason you want to force the startup, you can configure Minishift to treat these errors as warnings as follows:
+If you want to force Minishift to start despite any failed checks, you can instruct Minishift to treat these errors as warnings as follows:
 
-. For KVM/Libvirt on Linux, run the following command:
-
+- For KVM/Libvirt on Linux, run the following command:
++
 ----
 $ minishift config set warn-check-kvm-driver true
 ----
 
-. For xhyve on macOS, run the following command:
-
+- For xhyve on macOS, run the following command:
++
 ----
 $ minishift config set warn-check-xhyve-driver true
 ----
 
-. For Hyper-V on Windows, run the following command:
-
+- For Hyper-V on Windows, run the following command:
++
 ----
-# minishift config set warn-check-hyperv-driver true
+$ minishift config set warn-check-hyperv-driver true
 ----
 
-Other checks include to make sure the persistent volume storage is mounted, and/or enough storage is available. If for instance the Minishift VM has less than 95% of storage available, startup will fail. To be able to recover the data, it is possible to skip this test as follows:
+The following sections describe the different startup checks.
 
+Driver plug-in configuration::
+One of the startup checks verifies that the relevant driver plug-in is configured correctly.
+If this startup check fails, review the xref:../getting-started/setting-up-driver-plugin.adoc#[setting up the driver plug-in] topic and configure the driver.
+
+Persistent storage volume configuration and usage::
+Minishift checks whether the persistent storage volume is mounted and that enough disk space is available.
++
+For example, if the persistent storage volume uses more than 95% of the available disk space, then Minishift will not start.
++
+If you want to recover the data, you can skip this test and start Minishift to access the persistent volume.
+To skip this test, run run the following command:
++
 ----
 $ minishift config set skip-check-storage-usage true
 ----
 
-After the Minishift VM has started, we perform several basic network checks. These try to make sure if external connectivity is possible from within the Minishift VM. These checks by default are configured to treat the errors as warnings. This is due to the fact that the environment we are deployed in are quite diverse. To allow these checks to be useful for your environment you might want to configure them.
-
-One of the tests we perform is to ping an external host. You can change the host we try to reach with:
-
+External network connectivity::
+After the Minishift VM starts, it runs several network checks to verify whether external connectivity is possible from within the Minishift VM.
++
+By default, network checks are configured to treat the errors as warnings, because of the diversity of the development environments.
+You can configure the network checks to optimize them for your environment.
++
+For example, one of the network checks pings an external host. You can change the host by running the following command:
++
 ----
-$ minishift config set check-network-ping-host 208.67.222.222
+$ minishift config set check-network-ping-host <host-IP-address>
 ----
-
-Note: To make this test work for you, use the address of your internal DNS, proxy host or an external host that you can reach from your workstation.
-
-Since proxy connectivity can be problematic, we also provide a test which will try to retrieve an external resource. While this test is treated as warning by default, the resource retrieved can be changed with the following command:
-
++
+You can replace the `host IP address` with the address of your internal DNS server, proxy host, or an external host that you can reach from your machine.
++
+Because proxy connectivity might be problematic, you can run a check that tries to retrieve an external resource.
+You can change the resource to retrieve by running the following command:
++
 ----
 $ minishift config set check-network-http-host ddg.gg
 ----

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -230,7 +230,7 @@ func createDriverOptions(driver drivers.Driver, explicitOptions map[string]inter
 // CacheMinikubeISOFromURL download minishift ISO from a given URI.
 // It also checks sha256sum if present and then put ISO to cached directory.
 func (m *MachineConfig) CacheMinikubeISOFromURL() error {
-	fmt.Println(fmt.Sprintf("Downloading ISO '%s'", m.MinikubeISO))
+	fmt.Println(fmt.Sprintf("\n   Downloading ISO '%s'", m.MinikubeISO))
 	tmpISOFile, err := os.Create(m.GetISOCacheFilepath() + ".part")
 	if err != nil {
 		return err
@@ -400,9 +400,12 @@ func createHost(api libmachine.API, config MachineConfig) (*host.Host, error) {
 	}
 
 	if config.ShellProxyEnv != "" {
+		fmt.Printf("-- Setting proxy information ... ")
 		if err := minishiftUtil.SetProxyToShellEnv(h, config.ShellProxyEnv); err != nil {
+			fmt.Println("FAIL")
 			return nil, fmt.Errorf("Error setting proxy to VM: %s", err)
 		}
+		fmt.Println("OK")
 	}
 
 	return h, nil

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -57,7 +57,8 @@ var (
 )
 
 const (
-	fileScheme = "file"
+	fileScheme            = "file"
+	SshCommunicationError = "exit status 255"
 )
 
 //This init function is used to set the logtostderr variable to false so that INFO level log info does not clutter the CLI
@@ -595,7 +596,12 @@ func CreateSSHShell(api libmachine.API, args []string) error {
 		return err
 	}
 
-	return client.Shell(args...)
+	err = client.Shell(args...)
+	// do not fail if interactive and able to connect
+	if err != nil && len(args) == 0 && err.Error() != SshCommunicationError {
+		return nil
+	}
+	return err
 }
 
 func GetConsoleURL(api libmachine.API) (string, error) {

--- a/pkg/minishift/clusterup/clusterup.go
+++ b/pkg/minishift/clusterup/clusterup.go
@@ -64,10 +64,14 @@ type ClusterUpConfig struct {
 func ClusterUp(config *ClusterUpConfig, clusterUpParams map[string]string, runner util.Runner) error {
 	cmdArgs := []string{"cluster", "up", "--use-existing-config"}
 
+	fmt.Println("-- Checking `oc` support for startup flags ... ")
 	for key, value := range clusterUpParams {
+		fmt.Printf("   %s ... ", key)
 		if !oc.SupportFlag(key, config.OcPath, runner) {
+			fmt.Println("FAIL")
 			return errors.New(fmt.Sprintf("Flag %s is not supported for oc version %s. Use 'openshift-version' flag to select a different version of OpenShift.", key, config.OpenShiftVersion))
 		}
+		fmt.Println("OK")
 		cmdArgs = append(cmdArgs, "--"+key)
 		cmdArgs = append(cmdArgs, value)
 	}

--- a/pkg/minishift/hostfolder/hostfolder.go
+++ b/pkg/minishift/hostfolder/hostfolder.go
@@ -285,9 +285,8 @@ func determineHostIp(driver drivers.Driver) (string, error) {
 			hostip, _, _ := net.ParseCIDR(hostaddr)
 			if miniutil.IsIPReachable(driver, hostip.String(), false) {
 				return hostip.String(), nil
-			} else {
-				return "", errors.New("Unreachable")
 			}
+			return "", errors.New("Unreachable")
 		}
 	}
 

--- a/pkg/minishift/provisioner/minishift_provisioner.go
+++ b/pkg/minishift/provisioner/minishift_provisioner.go
@@ -111,8 +111,12 @@ func (provisioner *MinishiftProvisioner) Provision(swarmOptions swarm.Options, a
 	}
 	provisioner.EngineOptions.StorageDriver = storageDriver
 
+	fmt.Printf("\n   Setting hostname ... ")
 	if err := provisioner.SetHostname(provisioner.Driver.GetMachineName()); err != nil {
+		fmt.Println("FAIL")
 		return err
+	} else {
+		fmt.Println("OK")
 	}
 
 	if err := mcnutils.WaitFor(provisioner.dockerDaemonResponding); err != nil {

--- a/pkg/minishift/util/hostip.go
+++ b/pkg/minishift/util/hostip.go
@@ -23,6 +23,28 @@ import (
 	"github.com/docker/machine/libmachine/drivers"
 )
 
+func IsRetrievable(driver drivers.Driver, url string, printOutput bool) bool {
+	cmd := fmt.Sprintf(
+		"curl -s -m 5 %s > /dev/null 2>&1",
+		url)
+
+	if printOutput {
+		print(fmt.Sprintf("   Checking if '%s' is retrievable ... ", url))
+	}
+
+	if _, err := drivers.RunSSHCommandFromDriver(driver, cmd); err != nil {
+		if printOutput {
+			print("FAIL\n")
+		}
+		return false
+	}
+
+	if printOutput {
+		print("OK\n")
+	}
+	return true
+}
+
 // IsIPReachable returns true is IP address is reachable from the virtual instance
 func IsIPReachable(driver drivers.Driver, ip string, printOutput bool) bool {
 	cmd := fmt.Sprintf(

--- a/pkg/util/github/github.go
+++ b/pkg/util/github/github.go
@@ -125,7 +125,7 @@ func DownloadOpenShiftReleaseBinary(binaryType OpenShiftBinaryType, osType minis
 		return errors.Wrap(err, fmt.Sprintf("Cannot download OpenShift release asset %d", assetID))
 	}
 	if len(url) > 0 {
-		fmt.Println(fmt.Sprintf("Downloading OpenShift binary '%s' version '%s'", binaryType.String(), *release.TagName))
+		fmt.Println(fmt.Sprintf("-- Downloading OpenShift binary '%s' version '%s'", binaryType.String(), *release.TagName))
 		httpResp, err := http.Get(url)
 		if err != nil {
 			return errors.Wrap(err, "Cannot download OpenShift release asset.")


### PR DESCRIPTION
Heya,

I hope I didn't mess anything up in the files or in Git, first time trying this!

A few questions/notes about the content:

- startup vs. pre-flight check - You used "startup" in almost all the doc strings, but the file itself is called pre-flight. Both terms are ok but we need to be consistent. For now I standardzied on startup in the docs but if you want to change everything to pre-flight we can do that, we just need to decide which one to use :)

- check vs. test - In most cases you used "check" but when you talked about the network checks you used "tests". Since they're all a part of the same sequence of checks/tests, we should be consistent in the term as well. Again, both terms are ok grammatically and stylistically, but we should stick with one term. For now I changed "tests" to "checks" because "checks" was used more often, and it'll also help to search/replace later if we want to change it.

- I changed the numbered list to bulleted list in the force start commands, because they're not actually supposed to be done in sequence, but rather users should choose one based on their OS.

- Why is the Hyper-V doc string different from the others? The others use "installed" and the Hyper-V uses "configured"/"set". Also, why do we not refer users to the docs for Hyper-V?

- General notes: no need to write "please", we don't have to be that nice in docs ;) also, we should avoid using "we", and refer to what Minishift does or any component, since we are not personally there when the users use our software :)
